### PR TITLE
allow array to be updated using `obs.set`

### DIFF
--- a/add-listener.js
+++ b/add-listener.js
@@ -23,6 +23,6 @@ function addListener(observArray, observ) {
         valueList.splice(index, 1, value)
         setNonEnumerable(valueList, "_diff", [ [index, 1, value] ])
 
-        observArray.set(valueList)
+        observArray._observSet(valueList)
     })
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = ObservArray
 
 var splice = require("./splice.js")
 var put = require("./put.js")
+var set = require("./set.js")
 var transaction = require("./transaction.js")
 var ArrayMethods = require("./array-methods.js")
 var addListener = require("./add-listener.js")
@@ -44,6 +45,10 @@ function ObservArray(initialList) {
 
     var obs = Observ(initialState)
     obs.splice = splice
+
+    // override set and store original for later use
+    obs._observSet = obs.set
+    obs.set = set
 
     obs.get = get
     obs.getLength = getLength

--- a/put.js
+++ b/put.js
@@ -33,6 +33,6 @@ function put(index, value) {
 
     setNonEnumerable(valueList, "_diff", [valueArgs])
 
-    obs.set(valueList)
+    obs._observSet(valueList)
     return value
 }

--- a/set.js
+++ b/set.js
@@ -1,0 +1,51 @@
+var addListener = require("./add-listener.js")
+var setNonEnumerable = require("./lib/set-non-enumerable.js")
+var adiff = require("adiff")
+
+module.exports = set
+
+function set(rawList) {
+    var obs = this
+    var changes = adiff.diff(obs._list, rawList)
+    var valueList = obs().slice()
+
+    var valueChanges = changes.map(applyPatch.bind(obs, valueList))
+
+    setNonEnumerable(valueList, "_diff", valueChanges)
+
+    obs._observSet(valueList)
+    return changes
+}
+
+function applyPatch (valueList, args) {
+    var obs = this
+    var valueArgs = args.map(unpack)
+
+    valueList.splice.apply(valueList, valueArgs)
+    obs._list.splice.apply(obs._list, args)
+
+    var extraRemoveListeners = args.slice(2).map(function (observ) {
+        return typeof observ === "function" ?
+            addListener(obs, observ) :
+            null
+    })
+
+    extraRemoveListeners.unshift(args[0], args[1])
+    var removedListeners = obs._removeListeners.splice
+        .apply(obs._removeListeners, extraRemoveListeners)
+
+    removedListeners.forEach(function (removeObservListener) {
+        if (removeObservListener) {
+            removeObservListener()
+        }
+    })
+
+    return valueArgs
+}
+
+function unpack(value, index){
+    if (index === 0 || index === 1) {
+        return value
+    }
+    return typeof value === "function" ? value() : value
+}

--- a/splice.js
+++ b/splice.js
@@ -45,6 +45,6 @@ function splice(index, amount) {
 
     setNonEnumerable(valueList, "_diff", [valueArgs])
 
-    obs.set(valueList)
+    obs._observSet(valueList)
     return removed
 }

--- a/test/index.js
+++ b/test/index.js
@@ -330,3 +330,36 @@ test("batch changes with transactions", function (assert) {
 
     assert.end()
 })
+
+test("set updates array rather than replacing observ value", function (assert) {
+
+    var items = {
+        foo: Observ("foo"),
+        bar: Observ("bar"),
+        foobar: Observ("foobar"),
+        baz: Observ("baz"),
+        bazbar: Observ("bazbar")
+    }
+
+    var arr = ObservArray([ items.foo, items.bar, items.baz ])
+    var changes = []
+
+    arr(function (state) {
+        changes.push(state)
+    })
+
+    arr.set([ items.foo, items.foobar, items.baz, items.bazbar ])
+
+    assert.equal(changes.length, 1)
+
+    assert.deepEqual(changes[0].slice(), [
+        "foo","foobar","baz","bazbar"
+    ])
+
+    assert.deepEqual(changes[0]._diff, [
+        [3,0,"bazbar"],
+        [1,1,"foobar"]
+    ])
+
+    assert.end()
+})

--- a/transaction.js
+++ b/transaction.js
@@ -1,7 +1,3 @@
-var addListener = require("./add-listener.js")
-var setNonEnumerable = require("./lib/set-non-enumerable.js")
-var adiff = require("adiff")
-
 module.exports = transaction
 
 function transaction (func) {
@@ -9,49 +5,7 @@ function transaction (func) {
     var rawList = obs._list.slice()
 
     if (func(rawList) !== false){ // allow cancel
-
-        var changes = adiff.diff(obs._list, rawList)
-        var valueList = obs().slice()
-
-        var valueChanges = changes.map(applyPatch.bind(obs, valueList))
-
-        setNonEnumerable(valueList, "_diff", valueChanges)
-
-        obs.set(valueList)
-        return changes
+        return obs.set(rawList)
     }
 
-}
-
-function applyPatch (valueList, args) {
-    var obs = this
-    var valueArgs = args.map(unpack)
-
-    valueList.splice.apply(valueList, valueArgs)
-    obs._list.splice.apply(obs._list, args)
-
-    var extraRemoveListeners = args.slice(2).map(function (observ) {
-        return typeof observ === "function" ?
-            addListener(obs, observ) :
-            null
-    })
-
-    extraRemoveListeners.unshift(args[0], args[1])
-    var removedListeners = obs._removeListeners.splice
-        .apply(obs._removeListeners, extraRemoveListeners)
-
-    removedListeners.forEach(function (removeObservListener) {
-        if (removeObservListener) {
-            removeObservListener()
-        }
-    })
-
-    return valueArgs
-}
-
-function unpack(value, index){
-    if (index === 0 || index === 1) {
-        return value
-    }
-    return typeof value === "function" ? value() : value
 }


### PR DESCRIPTION
Currently `obs.set` simply falls back to observ's notify method, so if you call set on an observ-array everything just breaks. Trouble is, it appears to work, but the inner `._list` is never updated. This behavior is not really ideal and quite confusing. 

The new `transaction` method just about does what we want here, minus the initial shallow copy. This PR extracts out the update portion of transaction to a new `obs.set` method allowing the inner `._list` to be updated using `obs.set(rawList)`.

@Raynos I think this behavior of `set` makes more sense. What do you think?
